### PR TITLE
Lógica para al hacer el update del nickname

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\LoginRequest;
 use App\Http\Requests\StoreUserRequest;
+use App\Http\Requests\UpdateNicknameRequest;
 use App\Http\Resources\UserIndexResource;
 use App\Http\Resources\UserShowResource;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 
 class UserController extends Controller
@@ -64,16 +64,11 @@ class UserController extends Controller
   /**
    * Update the specified resource in storage.
    */
-  public function update(Request $request, User $user)
+  public function update(UpdateNicknameRequest $request, User $user): JsonResponse
   {
-    //
-  }
+    $data = $request->validated();
+    $user->update($data);
 
-  /**
-   * Remove the specified resource from storage.
-   */
-  public function destroy(User $user)
-  {
-    //
+    return response()->json(['message' => 'Nickname updated successfully'], 200);
   }
 }

--- a/app/Http/Requests/UpdateNicknameRequest.php
+++ b/app/Http/Requests/UpdateNicknameRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateNicknameRequest extends FormRequest
+{
+  /**
+   * Determine if the user is authorized to make this request.
+   */
+  public function authorize(): bool
+  {
+    return true;
+  }
+
+  /**
+   * Get the validation rules that apply to the request.
+   *
+   * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+   */
+  public function rules(): array
+  {
+    return [
+      'nickname' => 'required|string|max:255'
+    ];
+  }
+}


### PR DESCRIPTION
Lógica para que el usuario pueda actualizar su nickname del juego. Además, se quita la ruta 'destroy' del apiResource porque en teoría no se requiere la lógica para eliminar usuarios, solo sus partidas. Con lo cual, esto se hará en un método del GameController.